### PR TITLE
Add boot policy support to server claims

### DIFF
--- a/api/v1alpha1/serverclaim_types.go
+++ b/api/v1alpha1/serverclaim_types.go
@@ -12,6 +12,11 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.serverRef) || has(self.serverRef)", message="serverRef is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.serverSelector) || has(self.serverSelector)", message="serverSelector is required once set"
 type ServerClaimSpec struct {
+	// BootPolicy specifies how the server should be configured to boot from the network.
+	// +kubebuilder:validation:Enum=None;NetworkBootOnce;NetworkBootAlways
+	// +kubebuilder:default=NetworkBootOnce
+	BootPolicy BootPolicy `json:"bootPolicy,omitempty"`
+
 	// Power specifies the desired power state of the server.
 	// +required
 	Power Power `json:"power"`
@@ -39,6 +44,18 @@ type ServerClaimSpec struct {
 	// +required
 	Image string `json:"image"`
 }
+
+// BootPolicy defines the boot behavior for a server claimed by a ServerClaim.
+type BootPolicy string
+
+const (
+	// BootPolicyNone indicates that no network boot should be configured when reconciling the server claim.
+	BootPolicyNone BootPolicy = "None"
+	// BootPolicyNetworkBootOnce configures the server to boot from the network once on the next power cycle.
+	BootPolicyNetworkBootOnce BootPolicy = "NetworkBootOnce"
+	// BootPolicyNetworkBootAlways configures the server to set PXE boot on every reconciliation.
+	BootPolicyNetworkBootAlways BootPolicy = "NetworkBootAlways"
+)
 
 // Phase defines the possible phases of a ServerClaim.
 type Phase string

--- a/config/crd/bases/metal.ironcore.dev_serverclaims.yaml
+++ b/config/crd/bases/metal.ironcore.dev_serverclaims.yaml
@@ -74,6 +74,14 @@ spec:
               image:
                 description: Image specifies the boot image to be used for the server.
                 type: string
+              bootPolicy:
+                default: NetworkBootOnce
+                description: BootPolicy specifies how the server should be configured to boot from the network.
+                enum:
+                - None
+                - NetworkBootOnce
+                - NetworkBootAlways
+                type: string
               power:
                 description: Power specifies the desired power state of the server.
                 type: string

--- a/dist/chart/templates/crd/metal.ironcore.dev_serverclaims.yaml
+++ b/dist/chart/templates/crd/metal.ironcore.dev_serverclaims.yaml
@@ -80,6 +80,14 @@ spec:
               image:
                 description: Image specifies the boot image to be used for the server.
                 type: string
+              bootPolicy:
+                default: NetworkBootOnce
+                description: BootPolicy specifies how the server should be configured to boot from the network.
+                enum:
+                - None
+                - NetworkBootOnce
+                - NetworkBootAlways
+                type: string
               power:
                 description: Power specifies the desired power state of the server.
                 type: string

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -992,6 +992,24 @@ _Appears in:_
 | `uid` _[UID](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#uid-types-pkg)_ | UID is the uid of the referenced object. |  |  |
 
 
+#### BootPolicy
+
+_Underlying type:_ _string_
+
+BootPolicy defines the boot behavior for a server claimed by a ServerClaim.
+
+
+
+_Appears in:_
+- [ServerClaimSpec](#serverclaimspec)
+
+| Field | Description |
+| --- | --- |
+| `None` | BootPolicyNone indicates that no network boot should be configured when reconciling the server claim.<br /> |
+| `NetworkBootOnce` | BootPolicyNetworkBootOnce configures the server to boot from the network once on the next power cycle.<br /> |
+| `NetworkBootAlways` | BootPolicyNetworkBootAlways configures the server to set PXE boot on every reconciliation.<br /> |
+
+
 #### Phase
 
 _Underlying type:_ _string_
@@ -1247,6 +1265,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
+| `bootPolicy` _[BootPolicy](#bootpolicy)_ | BootPolicy specifies how the server should be configured to boot from the network. | NetworkBootOnce | Enum: None, NetworkBootOnce, NetworkBootAlways <br /> |
 | `power` _[Power](#power)_ | Power specifies the desired power state of the server. |  |  |
 | `serverRef` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#localobjectreference-v1-core)_ | ServerRef is a reference to a specific server to be claimed.<br />This field is optional and can be omitted if the server is to be selected using ServerSelector. |  | Optional: \{\} <br /> |
 | `serverSelector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.34/#labelselector-v1-meta)_ | ServerSelector specifies a label selector to identify the server to be claimed.<br />This field is optional and can be omitted if a specific server is referenced using ServerRef. |  | Optional: \{\} <br /> |
@@ -1616,5 +1635,3 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `Force` |  |
-
-

--- a/docs/concepts/serverclaims.md
+++ b/docs/concepts/serverclaims.md
@@ -43,6 +43,12 @@ spec:
     name: my-ignition-secret
 ```
 
+## Boot Policies
+
+- `bootPolicy: NetworkBootOnce` (default): The controller configures a one-time PXE boot when the server is powered on from an off state.
+- `bootPolicy: NetworkBootAlways`: The controller always refreshes the PXE boot configuration during reconciliation, ensuring every power cycle uses network boot.
+- `bootPolicy: None`: The controller does not configure PXE boot, preserving the existing boot configuration during power operations.
+
 ## Reconciliation Process
 
 - [`ServerBootConfiguration`](serverbootconfigurations.md):

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -439,12 +439,13 @@ func (r *ServerReconciler) handleReservedState(ctx context.Context, log logr.Log
 		return false, fmt.Errorf("failed to get ServerClaim: %w", err)
 	}
 
+	shouldConfigureNetworkBoot := shouldPXEBootServer(claim, server)
 	//TODO: handle working Reserved Server that was suddenly powered off but needs to boot from disk
-	if server.Status.PowerState == metalv1alpha1.ServerOffPowerState {
+	if shouldConfigureNetworkBoot {
 		if err := r.pxeBootServer(ctx, log, bmcClient, server); err != nil {
 			return false, fmt.Errorf("failed to boot server: %w", err)
 		}
-		log.V(1).Info("Server is powered off, booting Server in PXE")
+		log.V(1).Info("Server boot policy requires PXE boot configuration", "BootPolicy", claim.Spec.BootPolicy)
 	}
 	if err := r.ensureServerPowerState(ctx, log, bmcClient, server); err != nil {
 		return false, fmt.Errorf("failed to ensure server power state: %w", err)
@@ -789,6 +790,21 @@ func (r *ServerReconciler) pxeBootServer(ctx context.Context, log logr.Logger, b
 		return fmt.Errorf("failed to set PXE boot one for server: %w", err)
 	}
 	return nil
+}
+
+func shouldPXEBootServer(claim *metalv1alpha1.ServerClaim, server *metalv1alpha1.Server) bool {
+	if claim == nil || server == nil {
+		return false
+	}
+
+	switch claim.Spec.BootPolicy {
+	case "", metalv1alpha1.BootPolicyNetworkBootOnce:
+		return server.Status.PowerState == metalv1alpha1.ServerOffPowerState
+	case metalv1alpha1.BootPolicyNetworkBootAlways:
+		return true
+	default:
+		return false
+	}
 }
 
 func (r *ServerReconciler) extractServerDetailsFromRegistry(ctx context.Context, log logr.Logger, server *metalv1alpha1.Server) (bool, error) {

--- a/internal/controller/server_controller_test.go
+++ b/internal/controller/server_controller_test.go
@@ -795,6 +795,52 @@ var _ = Describe("Server Controller", func() {
 	})
 })
 
+var _ = Describe("shouldPXEBootServer", func() {
+	var claim *metalv1alpha1.ServerClaim
+	var server *metalv1alpha1.Server
+
+	BeforeEach(func() {
+		claim = &metalv1alpha1.ServerClaim{
+			Spec: metalv1alpha1.ServerClaimSpec{
+				BootPolicy: metalv1alpha1.BootPolicyNetworkBootOnce,
+			},
+		}
+		server = &metalv1alpha1.Server{
+			Status: metalv1alpha1.ServerStatus{
+				PowerState: metalv1alpha1.ServerOffPowerState,
+			},
+		}
+	})
+
+	It("returns true for NetworkBootAlways regardless of power state", func() {
+		claim.Spec.BootPolicy = metalv1alpha1.BootPolicyNetworkBootAlways
+		Expect(shouldPXEBootServer(claim, server)).To(BeTrue())
+
+		server.Status.PowerState = metalv1alpha1.ServerOnPowerState
+		Expect(shouldPXEBootServer(claim, server)).To(BeTrue())
+	})
+
+	It("returns true for NetworkBootOnce only when server is off", func() {
+		Expect(shouldPXEBootServer(claim, server)).To(BeTrue())
+
+		server.Status.PowerState = metalv1alpha1.ServerOnPowerState
+		Expect(shouldPXEBootServer(claim, server)).To(BeFalse())
+	})
+
+	It("treats an empty BootPolicy as NetworkBootOnce", func() {
+		claim.Spec.BootPolicy = ""
+		Expect(shouldPXEBootServer(claim, server)).To(BeTrue())
+
+		server.Status.PowerState = metalv1alpha1.ServerOnPowerState
+		Expect(shouldPXEBootServer(claim, server)).To(BeFalse())
+	})
+
+	It("returns false for BootPolicyNone", func() {
+		claim.Spec.BootPolicy = metalv1alpha1.BootPolicyNone
+		Expect(shouldPXEBootServer(claim, server)).To(BeFalse())
+	})
+})
+
 func deleteRegistrySystemIfExists(systemUUID string) {
 	response, err := http.Get(registryURL + "/systems/" + systemUUID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- add a `bootPolicy` field to `ServerClaim` with validation/defaults and document the available network boot behaviors
- gate PXE boot configuration in the server reconciler based on the claim boot policy and cover the decision logic with unit tests
- update CRDs, Helm chart templates, and API/concept docs to surface the new boot policy option

## Testing
- `go test ./...` *(fails: envtest binaries like etcd are unavailable; probe test missing `lldpctl`; docker is not installed for e2e build steps)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69441edc2e7c83288af42861b0396ab3)